### PR TITLE
update auth service to use new common library layout

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -65,7 +65,6 @@ func main() {
 		MaxAge:        12 * time.Hour,
 	}))
 
-
 	// use generic error-handling middleware
 	UseUserRoutes(router, conf)
 

--- a/auth/build.sh
+++ b/auth/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version="0.0.3"
+version="0.0.4"
 repo=basilnsage
 image=mwn-ticketapp.auth
 

--- a/auth/db.go
+++ b/auth/db.go
@@ -72,8 +72,8 @@ func (uc userColl) Read(ctx context.Context, user users.User) ([]users.User, err
 		}
 		foundUsers = append(foundUsers, users.User{
 			Email: email,
-			Hash: hash,
-			Uid: uid,
+			Hash:  hash,
+			Uid:   uid,
 		})
 	}
 	return foundUsers, nil

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -3,7 +3,7 @@ module github.com/basilnsage/mwn-ticketapp/auth
 go 1.15
 
 require (
-	github.com/basilnsage/mwn-ticketapp v0.0.0-20200714041703-691fb3f30688
+	github.com/basilnsage/mwn-ticketapp v0.0.0-20210213022547-49939b26690d
 	github.com/basilnsage/prometheus-gin-metrics v0.1.0-alpha
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-contrib/cors v1.3.1

--- a/auth/go.sum
+++ b/auth/go.sum
@@ -20,8 +20,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/basilnsage/mwn-ticketapp v0.0.0-20200714041703-691fb3f30688 h1:DXwRvakd79MLrDeDtqmk3Ln655ZkYBo3M7EzcQF29Oc=
-github.com/basilnsage/mwn-ticketapp v0.0.0-20200714041703-691fb3f30688/go.mod h1:O+uwqISb9iDJBqUCMMoLbBRQ67HmsAZjLdkSSsdYRas=
+github.com/basilnsage/mwn-ticketapp v0.0.0-20210213022547-49939b26690d h1:rBv6Rbsi9/zeaEpWwr+Gv5lVozoRr2ClxI0sH2AIR0M=
+github.com/basilnsage/mwn-ticketapp v0.0.0-20210213022547-49939b26690d/go.mod h1:O+uwqISb9iDJBqUCMMoLbBRQ67HmsAZjLdkSSsdYRas=
 github.com/basilnsage/prometheus-gin-metrics v0.1.0-alpha h1:A2sC7BImwvq7wyjLq2Lovt+09r8Api+q9gIdszO2hHo=
 github.com/basilnsage/prometheus-gin-metrics v0.1.0-alpha/go.mod h1:a5WyIk/iDLS1JWEmhUh+sO5ECVJi7bGSttmIgrFlAyQ=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/auth/routes.go
+++ b/auth/routes.go
@@ -7,15 +7,15 @@ import (
 	"time"
 
 	"github.com/basilnsage/mwn-ticketapp/auth/users"
-	"github.com/basilnsage/mwn-ticketapp/common/protos"
+	"github.com/basilnsage/mwn-ticketapp/common/events"
 	"github.com/gin-gonic/gin"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/crypto/bcrypt"
 )
 
 type userFormData struct {
-	Username string `json:"username" binding:required`
-	Password string `json:"password" binding:required`
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
 }
 
 func userFromForm(ctx *gin.Context) (*users.User, int, string, error) {
@@ -23,7 +23,7 @@ func userFromForm(ctx *gin.Context) (*users.User, int, string, error) {
 	err := ctx.Bind(data)
 	if err != nil {
 		return nil, http.StatusBadRequest,
-		"please provide a username and password", fmt.Errorf("ctx.Bind: %v", err)
+			"please provide a username and password", fmt.Errorf("ctx.Bind: %v", err)
 	}
 	userHash, err := bcrypt.GenerateFromPassword([]byte(data.Password), bcrypt.DefaultCost)
 	if err != nil {
@@ -41,7 +41,7 @@ func userFromPayload(ctx *gin.Context) (*users.User, int, string, error) {
 	if err != nil {
 		return nil, http.StatusBadRequest, "please provide a username and password", err
 	}
-	userProto := &protos.SignIn{}
+	userProto := &events.SignIn{}
 	if err = proto.Unmarshal(data, userProto); err != nil {
 		return nil, http.StatusBadRequest, "unable to parse provided credentials", err
 	}

--- a/auth/signin_test.go
+++ b/auth/signin_test.go
@@ -22,8 +22,8 @@ func TestSignin(t *testing.T) {
 	//}
 	user := &users.User{
 		Email: email,
-		Hash: passHash,
-		Uid: "0",
+		Hash:  passHash,
+		Uid:   "0",
 	}
 
 	payload, err := json.Marshal(&userFormData{Username: email, Password: pass})


### PR DESCRIPTION
This change updates the auth service to use the new common library layout.

Specifically, it references the new import path for the SignIn event (proto)